### PR TITLE
Refactor AnsiEscapes to use CrossPlatformUtil and update path separators in ResourceHelper

### DIFF
--- a/src/main/java/org/angellock/impl/managers/ResourceHelper.java
+++ b/src/main/java/org/angellock/impl/managers/ResourceHelper.java
@@ -17,9 +17,9 @@ public abstract class ResourceHelper extends AbstractJsonAccessor {
         File outFile = new File((defaultPath != null) ? defaultPath : getBaseConfigRoot());
         if (!outFile.exists()){
             if (defaultPath != null) {
-                log.warn(ConsoleTokens.colorizeText("&eSpecified config file &c" + defaultPath + "&e not found, &6reading from the default file: &3.\\" + getFullFileName()));
+                log.warn(ConsoleTokens.colorizeText("&eSpecified config file &c" + defaultPath + "&e not found, &6reading from the default file: &3." + File.separator + getFullFileName()));
             } else {
-                log.warn(ConsoleTokens.colorizeText("&eResource file path &5" + getFullFileName() + "&e is &dNOT-SET, &6reading from the default file: &3.\\" + getFullFileName()));
+                log.warn(ConsoleTokens.colorizeText("&eResource file path &5" + getFullFileName() + "&e is &dNOT-SET, &6reading from the default file: &3." + File.separator + getFullFileName()));
             }
             outFile = new File(this.getBaseConfigRoot());
         }
@@ -46,11 +46,11 @@ public abstract class ResourceHelper extends AbstractJsonAccessor {
                 }
                 in.close();
                 out.close();
-                log.info(ConsoleTokens.colorizeText("&9Extract config file &3\\" + getFullFileName()));
+                log.info(ConsoleTokens.colorizeText("&9Extract config file &3." + File.separator + getFullFileName()));
 
             }
             else {
-                log.error(ConsoleTokens.colorizeText("&dCould not extract fallback config file &3\\" + getFullFileName()));
+                log.error(ConsoleTokens.colorizeText("&dCould not extract fallback config file &3." + File.separator + getFullFileName()));
             }
         }
 //        this.configPath = Path.of(output, getFullFileName());

--- a/src/main/java/org/angellock/impl/util/CrossPlatformUtil.java
+++ b/src/main/java/org/angellock/impl/util/CrossPlatformUtil.java
@@ -1,0 +1,16 @@
+package org.angellock.impl.util;
+
+import com.sun.jna.Native;
+import org.angellock.impl.win32terminal.AnsiEscapes;
+
+public class CrossPlatformUtil {
+    public static boolean isWindows() {
+        String os = System.getProperty("os.name").toLowerCase();
+        return os.contains("win");
+    }
+
+    public static AnsiEscapes.Kernel32 loadWindowsKernel32() {
+        if (!isWindows()) return null;
+        return Native.load("kernel32", AnsiEscapes.Kernel32.class);
+    }
+}

--- a/src/main/java/org/angellock/impl/win32terminal/AnsiEscapes.java
+++ b/src/main/java/org/angellock/impl/win32terminal/AnsiEscapes.java
@@ -1,7 +1,6 @@
 package org.angellock.impl.win32terminal;
 
 import com.sun.jna.Library;
-import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import org.angellock.impl.util.ConsoleTokens;
 import org.jline.reader.LineReader;
@@ -13,13 +12,15 @@ import org.jline.terminal.TerminalBuilder;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
+import static org.angellock.impl.util.CrossPlatformUtil.loadWindowsKernel32;
+
 public class AnsiEscapes {
     private static final int TERMINAL_PROCESSING = 0x0004;
     private static Terminal winTerminal;
     private static LineReader reader;
 
-    private interface Kernel32 extends Library {
-        Kernel32 INSTANCE = Native.load("kernel32", Kernel32.class);
+    public interface Kernel32 extends Library {
+        Kernel32 INSTANCE = loadWindowsKernel32();
 
         Pointer GetStdHandle(int nStdHandle);
 
@@ -29,6 +30,7 @@ public class AnsiEscapes {
     }
 
     public static void enableAnsiSupport() {
+        if (Kernel32.INSTANCE == null) return;
         Pointer stdHandle = Kernel32.INSTANCE.GetStdHandle(-11);
         int[] consoleMode = new int[1];
         if (Kernel32.INSTANCE.GetConsoleMode(stdHandle, consoleMode) > 0) {


### PR DESCRIPTION
To solve questions in #1 , I added some cross-platform support for other OS. On my macos15, It work successfully.